### PR TITLE
fix: correct typo in container image repositories comment

### DIFF
--- a/.github/workflows/container-image-upgrade-test.yml
+++ b/.github/workflows/container-image-upgrade-test.yml
@@ -94,7 +94,7 @@ jobs:
           tags: |
             type=raw,value=latest
           labels: |
-            ## Container images repositories: https://artifacthub.io/docs/topics/repositories/container-images/
+            ## Container image repositories: https://artifacthub.io/docs/topics/repositories/container-images/
             # keep-sorted start sticky_comments=no
             # org.opencontainers.image.created - it is there by default
             # org.opencontainers.image.description - it is there by default (repository description)


### PR DESCRIPTION
Correct the wording in the comment regarding container image repositories for clarity.